### PR TITLE
Add package tests for a preact environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 ## Graph App Kit
 
-Build Neo4j Graph Apps using components and utilities from this graph app kit.  
-This kit should be considered to be 'under development' and the components in it can have breaking changes (i.e. until version `1.0.0` semver does not apply).
+Build Neo4j Graph Apps using components and utilities from this graph app kit.\
+This kit should be considered to be 'under development' and the components in it
+can have breaking changes (i.e. until version `1.0.0` semver does not apply).
 
 Browse source code and read README:s in sub directories for examples and docs.
 
@@ -11,19 +12,19 @@ Check out the [playground](https://styleguide-iqczcouawr.now.sh).
 
 ### User interface components
 
-| Component  | Description  |
-|---|---|
-| [&lt;Render>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/Render) | A declarative toggling component to mount / unmount child components under certain conditions.  |
-| [&lt;AsciiTable>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/AsciiTable) | Render your data in an text/ascii table with fixed width font.  |
-| [&lt;Chart>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/Chart) | Render your data in a chart visualization.  |
+| Component                                                                                    | Description                                                                                    |
+| -------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| [&lt;Render>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/Render)         | A declarative toggling component to mount / unmount child components under certain conditions. |
+| [&lt;AsciiTable>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/AsciiTable) | Render your data in an text/ascii table with fixed width font.                                 |
+| [&lt;Chart>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/ui/Chart)           | Render your data in a chart visualization.                                                     |
 
 ### Utility components
 
-| Component  | Description  |
-|---|---|
-| [&lt;Cypher>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/Cypher)  | A simple component to execute a Cypher query and return the result to your render function.  |
-| [&lt;DesktopIntegration>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/DesktopIntegration) | Easy integration for your app into the Neo4j Desktop API. Subscribe to events etc.  |
-| [&lt;DriverProvider>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/DriverProvider) | Provide your React application with a [`neo4j-driver`](https://github.com/neo4j/neo4j-javascript-driver) in application context. |
+| Component                                                                                                       | Description                                                                                                                      |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| [&lt;Cypher>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/Cypher)                         | A simple component to execute a Cypher query and return the result to your render function.                                      |
+| [&lt;DesktopIntegration>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/DesktopIntegration) | Easy integration for your app into the Neo4j Desktop API. Subscribe to events etc.                                               |
+| [&lt;DriverProvider>](https://github.com/neo4j-apps/graph-app-kit/tree/master/src/utils/DriverProvider)         | Provide your React application with a [`neo4j-driver`](https://github.com/neo4j/neo4j-javascript-driver) in application context. |
 
 ## Install and import
 
@@ -34,19 +35,21 @@ yarn add graph-app-kit --registry https://neo.jfrog.io/neo/api/npm/npm
 ```
 
 ```javascript
-import { Cypher } from 'graph-app-kit/utils/Cypher'
-import { DriverProvider } from 'graph-app-kit/utils/DriverProvider'
-import { Render } from 'graph-app-kit/ui/Render'
-import { Chart } from 'graph-app-kit/ui/Chart'
+import { Cypher } from "graph-app-kit/utils/Cypher";
+import { DriverProvider } from "graph-app-kit/utils/DriverProvider";
+import { Render } from "graph-app-kit/ui/Render";
+import { Chart } from "graph-app-kit/ui/Chart";
 ```
 
 ## Component playground / library
 
-There's an interactive playground to view and modify the components.  
-This is temporarily hosted at https://styleguide-iqczcouawr.now.sh.  
+There's an interactive playground to view and modify the components.\
+This is temporarily hosted at https://styleguide-iqczcouawr.now.sh.\
 Feedback wanted!
 
-To use the playground when developing components: `yarn playground` and to generate a static version to deploy: `yarn playground:build` (the artifacts end up in `styleguide/`)
+To use the playground when developing components: `yarn playground` and to
+generate a static version to deploy: `yarn playground:build` (the artifacts end
+up in `styleguide/`)
 
 ## Development mode
 
@@ -57,22 +60,36 @@ yarn install
 ```
 
 ### Dev environment setup
-The preferred way to develop new components is to either develop it directly in `src/dev/Component` or import there.  
-To start dev server on http://localhost:3000/ (loads `src/dev/index.js` in webpack): `yarn start`  
+
+The preferred way to develop new components is to either develop it directly in
+`src/dev/Component` or import there.\
+To start dev server on http://localhost:3000/ (loads `src/dev/index.js` in webpack):
+`yarn start`\
 To have continous testing (add tests to `src/dev/Component.test.js`): `yarn dev`
 
-### Exposing components 
-Here's a checklist for things to be done before opening a PR with a new component:
+### Exposing components
+
+Here's a checklist for things to be done before opening a PR with a new
+component:
 
 1. Restore `src/dev` to it's initial state.
-1. Name the component file `ComponentName.js` and the test file `ComponentName.test.js`.
-1. Export the component as a named export + a default export. Named for the kit users and default for placing it in the playground.
-1. Add an `index.js` in the components directory, which just exports the named import. i.e. `export { ComponentName } from './ComponentName'`.
-1. Execute `yarn test` and make sure the test coverage for the component is reasonable.
-1. Add a `README.md` in the components directory where you showcase one (or more) example usages and instructions of the component.
-1. Execute `yarn playground` to see it in action. Make sure it looks good and makes sense.
-1. Add an import test for the component in `test_package/package.test.js`. Execute `yarn test:package` and watch it fail.
-1. Add the component to the file `conf/kit_exports.js`. Follow the named / path convention.
+1. Name the component file `ComponentName.js` and the test file
+   `ComponentName.test.js`.
+1. Export the component as a named export + a default export. Named for the kit
+   users and default for placing it in the playground.
+1. Add an `index.js` in the components directory, which just exports the named
+   import. i.e. `export { ComponentName } from './ComponentName'`.
+1. Execute `yarn test` and make sure the test coverage for the component is
+   reasonable.
+1. Add a `README.md` in the components directory where you showcase one (or
+   more) example usages and instructions of the component.
+1. Execute `yarn playground` to see it in action. Make sure it looks good and
+   makes sense.
+1. Add an import test for the component in `test_package/react/package.test.js`
+   AND `test_package/preact/preact.test.js`. Execute `yarn test:package` and
+   watch it fail.
+1. Add the component to the file `conf/kit_exports.js`. Follow the named / path
+   convention.
 1. Execute `yarn test:package` again and watch it pass.
 1. Open a PR and wait for praise.
 

--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -1,0 +1,15 @@
+module.exports = {
+  rootDir: "../",
+  collectCoverageFrom: ["src/**/*.{js,jsx}"],
+  setupFiles: ["<rootDir>/config/polyfills.js"],
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest"
+  },
+  transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
+  moduleNameMapper: {
+    "^react-native$": "react-native-web",
+    "^graph-app-kit(.*)": "<rootDir>/src$1"
+  },
+  moduleFileExtensions: ["web.js", "js", "json", "web.jsx", "jsx", "node"]
+};

--- a/config/jest.config.preact.js
+++ b/config/jest.config.preact.js
@@ -1,0 +1,11 @@
+const base = require("./jest.config.base");
+
+const out = Object.assign({}, base, {
+  moduleNameMapper: Object.assign({}, base.moduleNameMapper, {
+    "^react$": "preact-compat",
+    "^react-dom$": "preact-compat"
+  }),
+  snapshotSerializers: ["preact-render-spy/snapshot"]
+});
+
+module.exports = out;

--- a/package.json
+++ b/package.json
@@ -5,9 +5,14 @@
   "scripts": {
     "build": "node scripts/build.js",
     "test": "npm run dev -- --coverage",
-    "test:package": "yarn build && CI=true node scripts/test.js --env=jsdom test_package",
+    "test:package": "yarn build && yarn test:react && yarn test:preact",
+    "test:react":
+      "CI=true node scripts/test.js --config=config/jest.config.base.js --env=jsdom test_package/react",
+    "test:preact":
+      "CI=true node scripts/test.js --config=config/jest.config.preact.js --env=jsdom test_package/preact",
     "test:all": "yarn test && yarn test:package",
-    "dev": "node scripts/test.js --env=jsdom src",
+    "dev":
+      "node scripts/test.js --config=config/jest.config.base.js --env=jsdom src",
     "lint": "eslint --fix --ext .js --ext .jsx src",
     "precommit": "lint-staged",
     "prepare-dist": "node scripts/release.js",
@@ -18,10 +23,7 @@
     "start": "node scripts/start.js"
   },
   "lint-staged": {
-    "*.{js,jsx,json,css}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,jsx,json,css}": ["prettier --write", "git add"]
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -30,6 +32,7 @@
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react-app": "^3.0.3",
     "babel-runtime": "6.26.0",
@@ -52,6 +55,9 @@
     "lint-staged": "^4.2.3",
     "postcss-flexbugs-fixes": "^3.2.0",
     "postcss-loader": "^2.0.8",
+    "preact": "^8.2.6",
+    "preact-compat": "^3.17.0",
+    "preact-render-spy": "^1.2.1",
     "prettier": "^1.7.4",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
@@ -73,37 +79,8 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0"
   },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/polyfills.js"
-    ],
-    "testEnvironment": "node",
-    "transform": {
-      "^.+\\.(js|jsx)$": "<rootDir>/node_modules/babel-jest"
-    },
-    "transformIgnorePatterns": [
-      "[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"
-    ],
-    "moduleNameMapper": {
-      "^react-native$": "react-native-web",
-      "^graph-app-kit(.*)": "<rootDir>/src$1"
-    },
-    "moduleFileExtensions": [
-      "web.js",
-      "js",
-      "json",
-      "web.jsx",
-      "jsx",
-      "node"
-    ]
-  },
   "babel": {
-    "presets": [
-      "react-app"
-    ]
+    "presets": ["react-app"]
   },
   "dependencies": {
     "@data-ui/radial-chart": "0.0.11",

--- a/src/ui/Render/Render.js
+++ b/src/ui/Render/Render.js
@@ -1,3 +1,5 @@
+import React from "react";
+
 export const Render = ({ if: cond, children }) => {
-  return cond ? children : null;
+  return cond ? React.Children.only(children) : null;
 };

--- a/src/ui/Render/Render.test.js
+++ b/src/ui/Render/Render.test.js
@@ -3,7 +3,11 @@ import TestRenderer from "react-test-renderer";
 import { Render } from "./Render";
 
 it("loads Render (no output)", () => {
-  const out = TestRenderer.create(<Render if={1 === 2}>Hello</Render>);
+  const out = TestRenderer.create(
+    <Render if={1 === 2}>
+      <span>Hello</span>
+    </Render>
+  );
   expect(out.toJSON()).toEqual(null);
 });
 it("loads Render (with output)", () => {

--- a/test_package/preact/.babelrc
+++ b/test_package/preact/.babelrc
@@ -1,0 +1,13 @@
+{
+  "presets": ["env"],
+  "ignore": ["dist/", "coverage/"],
+  "plugins": [
+    "babel-plugin-transform-object-rest-spread",
+    [
+      "transform-react-jsx",
+      {
+        "pragma": "h"
+      }
+    ]
+  ]
+}

--- a/test_package/preact/__snapshots__/preact.test.js.snap
+++ b/test_package/preact/__snapshots__/preact.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AsciiTable works 1`] = `
+"╒═══╕
+│\\"x\\"│
+╞═══╡
+│\\"y\\"│
+└───┘"
+`;
+
+exports[`Chart works 1`] = `
+<div>
+  <div>
+    <undefined></undefined>
+    <div
+      style="display: flex; flex-direction: column;"
+      class="vx-legend"
+    >
+    </div>
+  </div>
+  <h2>Static circular data</h2>
+</div>
+`;
+
+exports[`Cypher works 1`] = `"pending"`;
+
+exports[`DesktopIntegration works 1`] = `null`;
+
+exports[`DriverProvider works 1`] = `"Hello"`;
+
+exports[`Render works 1`] = `<p>Hello</p>`;

--- a/test_package/preact/preact.test.js
+++ b/test_package/preact/preact.test.js
@@ -1,29 +1,35 @@
-import React from "react";
-import TestRenderer from "react-test-renderer";
+import { h } from "preact";
+/** @jsx h */
+import { deep } from "preact-render-spy";
 
 // Package exports ui/
-import { Render } from "../dist/ui/Render";
-import { AsciiTable } from "../dist/ui/AsciiTable";
-import { Chart } from "../dist/ui/Chart";
+import { Render } from "../../dist/ui/Render";
+import { AsciiTable } from "../../dist/ui/AsciiTable";
+import { Chart } from "../../dist/ui/Chart";
 
 // Package exports utils/
-import { Cypher } from "../dist/utils/Cypher";
-import { DesktopIntegration } from "../dist/utils/DesktopIntegration";
-import { DriverProvider } from "../dist/utils/DriverProvider";
+import { Cypher } from "../../dist/utils/Cypher";
+import { DesktopIntegration } from "../../dist/utils/DesktopIntegration";
+import { DriverProvider } from "../../dist/utils/DriverProvider";
 
 // ui/
 test("Render works", () => {
-  const out = TestRenderer.create(<Render if={true}>Hello</Render>);
-  expect(out.toJSON()).toMatchSnapshot();
+  const context = deep(
+    <Render if={true}>
+      <p>Hello</p>
+    </Render>
+  );
+  expect(context.output()).toMatchSnapshot();
 });
 test("AsciiTable works", () => {
   const data = [["x"], ["y"]];
-  const out = TestRenderer.create(<AsciiTable data={data} />);
-  expect(out.toJSON()).toMatchSnapshot();
+  const context = deep(<AsciiTable data={data} />);
+  context.rerender();
+  expect(context.text()).toMatchSnapshot();
 });
 test("Chart works", () => {
   const data = [{ label: "Used", value: 30 }, { label: "Free", value: 20 }];
-  const out = TestRenderer.create(
+  const context = deep(
     <Chart
       data={data}
       title="Static circular data"
@@ -31,12 +37,12 @@ test("Chart works", () => {
       type="json"
     />
   );
-  expect(out.toJSON()).toMatchSnapshot();
+  expect(context.output()).toMatchSnapshot();
 });
 
 // utils/
 test("Cypher works", () => {
-  const out = TestRenderer.create(
+  const context = deep(
     <Cypher
       driver={resolvingDriver(0, "no!")}
       query="RETURN rand() as n"
@@ -45,19 +51,17 @@ test("Cypher works", () => {
       }}
     />
   );
-  expect(out.toJSON()).toMatchSnapshot();
+  expect(context.output()).toMatchSnapshot();
 });
 test("DesktopIntegration works", () => {
-  const out = TestRenderer.create(
-    <DesktopIntegration integrationPoint={true} />
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  const context = deep(<DesktopIntegration integrationPoint={true} />);
+  expect(context.output()).toMatchSnapshot();
 });
 test("DriverProvider works", () => {
-  const out = TestRenderer.create(
+  const context = deep(
     <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>
   );
-  expect(out.toJSON()).toMatchSnapshot();
+  expect(context.output()).toMatchSnapshot();
 });
 
 // Helpers

--- a/test_package/react/__snapshots__/package.test.js.snap
+++ b/test_package/react/__snapshots__/package.test.js.snap
@@ -255,4 +255,8 @@ exports[`DesktopIntegration works 1`] = `null`;
 
 exports[`DriverProvider works 1`] = `"Hello"`;
 
-exports[`Render works 1`] = `"Hello"`;
+exports[`Render works 1`] = `
+<p>
+  Hello
+</p>
+`;

--- a/test_package/react/package.test.js
+++ b/test_package/react/package.test.js
@@ -1,0 +1,84 @@
+import React from "react";
+import TestRenderer from "react-test-renderer";
+
+// Package exports ui/
+import { Render } from "../../dist/ui/Render";
+import { AsciiTable } from "../../dist/ui/AsciiTable";
+import { Chart } from "../../dist/ui/Chart";
+
+// Package exports utils/
+import { Cypher } from "../../dist/utils/Cypher";
+import { DesktopIntegration } from "../../dist/utils/DesktopIntegration";
+import { DriverProvider } from "../../dist/utils/DriverProvider";
+
+// ui/
+test("Render works", () => {
+  const out = TestRenderer.create(
+    <Render if={true}>
+      <p>Hello</p>
+    </Render>
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+test("AsciiTable works", () => {
+  const data = [["x"], ["y"]];
+  const out = TestRenderer.create(<AsciiTable data={data} />);
+  expect(out.toJSON()).toMatchSnapshot();
+});
+test("Chart works", () => {
+  const data = [{ label: "Used", value: 30 }, { label: "Free", value: 20 }];
+  const out = TestRenderer.create(
+    <Chart
+      data={data}
+      title="Static circular data"
+      chartType="doughnut"
+      type="json"
+    />
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+
+// utils/
+test("Cypher works", () => {
+  const out = TestRenderer.create(
+    <Cypher
+      driver={resolvingDriver(0, "no!")}
+      query="RETURN rand() as n"
+      render={({ pending, error, result, tick }) => {
+        return pending ? "pending" : error ? error.message : result;
+      }}
+    />
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+test("DesktopIntegration works", () => {
+  const out = TestRenderer.create(
+    <DesktopIntegration integrationPoint={true} />
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+test("DriverProvider works", () => {
+  const out = TestRenderer.create(
+    <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+
+// Helpers
+const sleep = (secs, shouldResolve = true, message) =>
+  new Promise((resolve, reject) => {
+    setTimeout(
+      () => (shouldResolve ? resolve(message) : reject(new Error(message))),
+      secs * 1000
+    );
+  });
+
+const driver = (shouldResolve = true, waitSecs = 0, message = "") => ({
+  session: () => ({
+    close: () => {},
+    run: () => sleep(waitSecs, shouldResolve, message)
+  })
+});
+
+const resolvingDriver = (waitSecs = 0, resolveTo = "Resolved") =>
+  driver(true, waitSecs, resolveTo);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2592,7 +2592,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.7.0:
+es-abstract@^1.6.1, es-abstract@^1.7.0:
   version "1.9.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/es-abstract/-/es-abstract-1.9.0.tgz#690829a07cae36b222e7fd9b75c0d0573eb25227"
   dependencies:
@@ -3306,7 +3306,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -3756,6 +3756,12 @@ ignore@^3.3.3:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.5.tgz#c4e715455f6073a8d7e5dae72d2fc9d71663dba6"
 
+immutability-helper@^2.1.2:
+  version "2.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/immutability-helper/-/immutability-helper-2.5.0.tgz#01ea7204334997c645bdfa7eb22e8b84c970946e"
+  dependencies:
+    invariant "^2.2.0"
+
 import-local@^0.1.1:
   version "0.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/import-local/-/import-local-0.1.1.tgz#b1179572aacdc11c6a91009fb430dbcab5f668a8"
@@ -3852,7 +3858,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -4805,6 +4811,10 @@ lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
@@ -5327,6 +5337,15 @@ object-hash@^1.1.4:
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.entries@^1.0.4:
+  version "1.0.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/object.entries/-/object.entries-1.0.4.tgz#1bf9a4dd2288f5b33f3a993d257661f05d161a5f"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -5932,6 +5951,38 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.13:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
+preact-compat@^3.17.0:
+  version "3.17.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-render-spy@^1.2.1:
+  version "1.2.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-render-spy/-/preact-render-spy-1.2.1.tgz#5f4101c8f15f39162db7d274230935cfb3f07f5c"
+  dependencies:
+    lodash.isequal "^4.5.0"
+    object.entries "^1.0.4"
+    preact-render-to-string "^3.6.3"
+
+preact-render-to-string@^3.6.0, preact-render-to-string@^3.6.3:
+  version "3.7.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-render-to-string/-/preact-render-to-string-3.7.0.tgz#7db4177454bc01395e0d01d6ac07bc5e838e31ee"
+  dependencies:
+    pretty-format "^3.5.1"
+
+preact-transition-group@^1.1.0:
+  version "1.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
+
+preact@^8.2.6:
+  version "8.2.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact/-/preact-8.2.6.tgz#0028b426ef98fcca741a3c617ff5b813b9a947c7"
+
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -5973,6 +6024,10 @@ pretty-format@^21.2.1:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^3.5.1:
+  version "3.8.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/pretty-format/-/pretty-format-3.8.0.tgz#bfbed56d5e9a776645f4b1ff7aa1a3ac4fa3c385"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6006,7 +6061,7 @@ prop-types@15.5.10:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.6.0:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -7049,6 +7104,10 @@ ssri@^4.1.6:
 staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
+standalone-react-addons-pure-render-mixin@^0.1.1:
+  version "0.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
 
 state-toggle@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Note in the snapshot file that the `<Chart>` does not work properly in Preact at the moment.
Run with `yarn test:package` or `yarn build && yarn test:preact`.

We run tests where `preact-compat` is available, so that's what we support.