### PR TITLE
Expose new bundle entry at graph-app-kit/components

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,19 @@ component:
    users and default for placing it in the playground.
 1. Add an `index.js` in the components directory, which just exports the named
    import. i.e. `export { ComponentName } from './ComponentName'`.
+1. If you're creating a component, make sure to add the export to
+   `src/components/index.js` as well.
 1. Execute `yarn test` and make sure the test coverage for the component is
    reasonable.
 1. Add a `README.md` in the components directory where you showcase one (or
    more) example usages and instructions of the component.
 1. Execute `yarn playground` to see it in action. Make sure it looks good and
    makes sense.
-1. Add an import test for the component in `test_package/react/package.test.js`
-   AND `test_package/preact/preact.test.js`. Execute `yarn test:package` and
-   watch it fail.
+1. Add an import test for the component (both direct import and through
+   `components` if you're making a component) in
+   `test_package/react/package.test.js` AND
+   `test_package/preact/preact.test.js`. Execute `yarn test:package` and watch
+   it fail.
 1. Add the component to the file `conf/kit_exports.js`. Follow the named / path
    convention.
 1. Execute `yarn test:package` again and watch it pass.

--- a/config/kit_exports.js
+++ b/config/kit_exports.js
@@ -7,6 +7,7 @@ const appDirectory = fs.realpathSync(process.cwd());
 const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 
 module.exports = {
+  components: resolveApp("src/components"),
   "components/AsciiTable": resolveApp("src/components/AsciiTable"),
   "components/Chart": resolveApp("src/components/Chart"),
   "components/Render": resolveApp("src/components/Render"),

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,0 +1,8 @@
+export { AsciiTable } from "./AsciiTable";
+export { Chart } from "./Chart";
+export { Cypher } from "./Cypher";
+export { DesktopIntegration } from "./DesktopIntegration";
+export { DriverProvider } from "./DriverProvider";
+export { CypherEditor } from "./Editor";
+export { GraphAppBase } from "./GraphAppBase";
+export { Render } from "./Render";

--- a/test_package/preact/__snapshots__/preact.test.js.snap
+++ b/test_package/preact/__snapshots__/preact.test.js.snap
@@ -1,11 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AsciiTable works 1`] = `
-"╒═══╕
-│\\"x\\"│
-╞═══╡
-│\\"y\\"│
-└───┘"
+<pre>
+  ╒═══╕
+  │&quot;x&quot;│
+  ╞═══╡
+  │&quot;y&quot;│
+  └───┘
+</pre>
+`;
+
+exports[`AsciiTable works 2`] = `
+<pre>
+  ╒═══╕
+  │&quot;x&quot;│
+  ╞═══╡
+  │&quot;y&quot;│
+  └───┘
+</pre>
 `;
 
 exports[`Chart works 1`] = `
@@ -22,18 +34,40 @@ exports[`Chart works 1`] = `
 </div>
 `;
 
-exports[`Cypher works 1`] = `"pending"`;
-
-exports[`CypherEditor works 1`] = `<div class="ReactCodeMirror"></div>`;
-
-exports[`DesktopIntegration works 1`] = `null`;
-
-exports[`DriverProvider works 1`] = `"Hello"`;
-
-exports[`GraphAppBase works 1`] = `
+exports[`Chart works 2`] = `
 <div>
-  <p>Hello</p>
+  <div>
+    <undefined></undefined>
+    <div
+      style="display: flex; flex-direction: column;"
+      class="vx-legend"
+    >
+    </div>
+  </div>
+  <h2>Static circular data</h2>
 </div>
 `;
 
+exports[`Cypher works 1`] = `"pending"`;
+
+exports[`Cypher works 2`] = `"pending"`;
+
+exports[`CypherEditor works 1`] = `<div class="ReactCodeMirror"></div>`;
+
+exports[`CypherEditor works 2`] = `<div class="ReactCodeMirror"></div>`;
+
+exports[`DesktopIntegration works 1`] = `null`;
+
+exports[`DesktopIntegration works 2`] = `null`;
+
+exports[`DriverProvider works 1`] = `"Hello"`;
+
+exports[`DriverProvider works 2`] = `"Hello"`;
+
+exports[`GraphAppBase works 1`] = `<div>Hello</div>`;
+
+exports[`GraphAppBase works 2`] = `<div>Hello</div>`;
+
 exports[`Render works 1`] = `<p>Hello</p>`;
+
+exports[`Render works 2`] = `<p>Hello</p>`;

--- a/test_package/preact/preact.test.js
+++ b/test_package/preact/preact.test.js
@@ -12,71 +12,139 @@ import { DriverProvider } from "../../dist/components/DriverProvider";
 import { CypherEditor } from "../../dist/components/Editor";
 import { GraphAppBase } from "../../dist/components/GraphAppBase";
 
+// Package exports components/
+import {
+  Render as RenderC,
+  AsciiTable as AsciiTableC,
+  Chart as ChartC,
+  Cypher as CypherC,
+  DesktopIntegration as DesktopIntegrationC,
+  DriverProvider as DriverProviderC,
+  CypherEditor as CypherEditorC,
+  GraphAppBase as GraphAppBaseC
+} from "../../dist/components";
+
 // Package exports lib/
 import { shallowEqual } from "../../dist/lib/utils";
 
 // components
 test("Render works", () => {
-  const context = deep(
+  const cs = [
     <Render if={true}>
       <p>Hello</p>
-    </Render>
-  );
-  expect(context.output()).toMatchSnapshot();
+    </Render>,
+    <RenderC if={true}>
+      <p>Hello</p>
+    </RenderC>
+  ];
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("AsciiTable works", () => {
   const data = [["x"], ["y"]];
-  const context = deep(<AsciiTable data={data} />);
-  context.rerender();
-  expect(context.text()).toMatchSnapshot();
+  const cs = [<AsciiTable data={data} />, <AsciiTableC data={data} />];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    context.rerender();
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("Chart works", () => {
   const data = [{ label: "Used", value: 30 }, { label: "Free", value: 20 }];
-  const context = deep(
+  const cs = [
     <Chart
       data={data}
       title="Static circular data"
       chartType="doughnut"
       type="json"
+    />,
+    <ChartC
+      data={data}
+      title="Static circular data"
+      chartType="doughnut"
+      type="json"
     />
-  );
-  expect(context.output()).toMatchSnapshot();
+  ];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("CypherEditor works", () => {
-  const context = deep(<CypherEditor />);
-  expect(context.output()).toMatchSnapshot();
+  const cs = [<CypherEditor />, <CypherEditorC />];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("Cypher works", () => {
-  const context = deep(
+  const cs = [
     <Cypher
       driver={resolvingDriver(0, "no!")}
       query="RETURN rand() as n"
       render={({ pending, error, result, tick }) => {
         return pending ? "pending" : error ? error.message : result;
       }}
+    />,
+    <CypherC
+      driver={resolvingDriver(0, "no!")}
+      query="RETURN rand() as n"
+      render={({ pending, error, result, tick }) => {
+        return pending ? "pending" : error ? error.message : result;
+      }}
     />
-  );
-  expect(context.output()).toMatchSnapshot();
+  ];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("DesktopIntegration works", () => {
-  const context = deep(<DesktopIntegration integrationPoint={true} />);
-  expect(context.output()).toMatchSnapshot();
+  const cs = [
+    <DesktopIntegration integrationPoint={true} />,
+    <DesktopIntegrationC integrationPoint={true} />
+  ];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("DriverProvider works", () => {
-  const context = deep(
-    <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>
-  );
-  expect(context.output()).toMatchSnapshot();
+  const cs = [
+    <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>,
+    <DriverProviderC driver={resolvingDriver(0, "yes")}>Hello</DriverProviderC>
+  ];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 test("GraphAppBase works", () => {
-  const context = deep(
+  const cs = [
     <GraphAppBase
       integrationPoint={null}
-      render={() => <p>Hello</p>}
+      render={() => "Hello"}
+      driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
+    />,
+    <GraphAppBaseC
+      integrationPoint={null}
+      render={() => "Hello"}
       driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
     />
-  );
-  expect(context.output()).toMatchSnapshot();
+  ];
+
+  cs.forEach(c => {
+    const context = deep(c);
+    expect(context.output()).toMatchSnapshot();
+  });
 });
 
 // Utils

--- a/test_package/react/__snapshots__/package.test.js.snap
+++ b/test_package/react/__snapshots__/package.test.js.snap
@@ -10,7 +10,256 @@ exports[`AsciiTable works 1`] = `
 </pre>
 `;
 
+exports[`AsciiTable works 2`] = `
+<pre>
+  ╒═══╕
+│"x"│
+╞═══╡
+│"y"│
+└───┘
+</pre>
+`;
+
 exports[`Chart works 1`] = `
+<div>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        className={null}
+        style={
+          Object {
+            "display": "inline-block",
+            "position": "relative",
+          }
+        }
+      >
+        <svg
+          aria-label="This is a radial-chart chart of..."
+          height={500}
+          role="img"
+          width={500}
+        >
+          <g
+            className="cx-group"
+            transform="translate(300, 200)"
+          >
+            <g>
+              <g
+                className="cx-group vx-arcs-group"
+                transform="translate(0, 0)"
+              >
+                <g>
+                  <path
+                    className="vx-arc"
+                    d="M6.661338147750939e-15,-116.96153213770758A3,3,0,0,1,3.0769230769230838,-119.96054578226418A120,120,0,1,1,-68.02175660815573,98.85869019939938A3,3,0,0,1,-68.74826367607669,94.62386718753697L-42.87207476857917,59.00834860456068A3,3,0,0,1,-38.78289952029867,58.27423705891324A70,70,0,1,0,2.8767123287671192,-69.94086449406755A3,3,0,0,1,3.552713678800501e-15,-72.93833011524188Z"
+                    fill="#15aabf"
+                    fillOpacity={1}
+                    onMouseLeave={[Function]}
+                    onMouseMove={[Function]}
+                    stroke="#fff"
+                    strokeWidth={1}
+                  />
+                </g>
+                <g>
+                  <path
+                    className="vx-arc"
+                    d="M-68.74826367607668,94.62386718753697A3,3,0,0,1,-73.00032272738618,95.24155018529186A120,120,0,0,1,-3.0769230769231024,-119.96054578226418A3,3,0,0,1,-2.1316282072803006e-14,-116.96153213770758L-1.2878587085651816e-14,-72.93833011524188A3,3,0,0,1,-2.8767123287671357,-69.94086449406755A70,70,0,0,0,-43.437517844099716,54.89245889503875A3,3,0,0,1,-42.87207476857916,59.00834860456069Z"
+                    fill="#fab005"
+                    fillOpacity={1}
+                    onMouseLeave={[Function]}
+                    onMouseMove={[Function]}
+                    stroke="#fff"
+                    strokeWidth={1}
+                  />
+                </g>
+              </g>
+              <g
+                className="cx-group vx-arcs-group"
+                transform="translate(0, 0)"
+              >
+                <g>
+                  <path
+                    className="vx-arc"
+                    d="M9.184850993605149e-15,-150A150,150,0,1,1,-88.167787843871,121.35254915624209A150,150,0,1,0,9.184850993605149e-15,-150Z"
+                    fill="none"
+                    fillOpacity={0}
+                    stroke="none"
+                    strokeWidth={0}
+                  />
+                  <text
+                    fill="#495057"
+                    fontFamily="BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+                    fontSize={12}
+                    fontWeight={700}
+                    letterSpacing={0.4}
+                    paintOrder="stroke"
+                    pointerEvents="none"
+                    stroke="none"
+                    textAnchor="middle"
+                    x={142.65847744427302}
+                    y={46.35254915624214}
+                  >
+                    60.00%
+                  </text>
+                </g>
+                <g>
+                  <path
+                    className="vx-arc"
+                    d="M-88.167787843871,121.35254915624209A150,150,0,0,1,-2.7554552980815446e-14,-150A150,150,0,0,0,-88.167787843871,121.35254915624209Z"
+                    fill="none"
+                    fillOpacity={0}
+                    stroke="none"
+                    strokeWidth={0}
+                  />
+                  <text
+                    fill="#495057"
+                    fontFamily="BlinkMacSystemFont,Roboto,Helvetica Neue,sans-serif"
+                    fontSize={12}
+                    fontWeight={700}
+                    letterSpacing={0.4}
+                    paintOrder="stroke"
+                    pointerEvents="none"
+                    stroke="none"
+                    textAnchor="middle"
+                    x={-142.65847744427305}
+                    y={-46.35254915624209}
+                  >
+                    40.00%
+                  </text>
+                </g>
+              </g>
+            </g>
+          </g>
+        </svg>
+        <style
+          type="text/css"
+        >
+          
+      .vx-arc:hover {
+        opacity: 0.7;
+      }
+    
+        </style>
+      </div>
+    </div>
+    <div
+      className="vx-legend"
+      style={
+        Object {
+          "display": "flex",
+          "flexDirection": "column",
+        }
+      }
+    >
+      <div
+        className="vx-legend-item"
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "margin": "0",
+          }
+        }
+      >
+        <div
+          className="vx-legend-shape"
+          style={
+            Object {
+              "display": "flex",
+              "height": "#15aabf",
+              "margin": "2px 4px 2px 0",
+              "width": "#15aabf",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "background": "#15aabf",
+                "height": 15,
+                "style": undefined,
+                "width": 15,
+              }
+            }
+          />
+        </div>
+        <div
+          className="vx-legend-label"
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "justifyContent": "left",
+              "margin": "0 4px",
+            }
+          }
+        >
+          Used
+        </div>
+      </div>
+      <div
+        className="vx-legend-item"
+        style={
+          Object {
+            "alignItems": "center",
+            "display": "flex",
+            "flexDirection": "row",
+            "margin": "0",
+          }
+        }
+      >
+        <div
+          className="vx-legend-shape"
+          style={
+            Object {
+              "display": "flex",
+              "height": "#fab005",
+              "margin": "2px 4px 2px 0",
+              "width": "#fab005",
+            }
+          }
+        >
+          <div
+            style={
+              Object {
+                "background": "#fab005",
+                "height": 15,
+                "style": undefined,
+                "width": 15,
+              }
+            }
+          />
+        </div>
+        <div
+          className="vx-legend-label"
+          style={
+            Object {
+              "display": "flex",
+              "flex": "1",
+              "justifyContent": "left",
+              "margin": "0 4px",
+            }
+          }
+        >
+          Free
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>
+    Static circular data
+  </h2>
+</div>
+`;
+
+exports[`Chart works 2`] = `
 <div>
   <div>
     <div
@@ -251,7 +500,15 @@ exports[`Chart works 1`] = `
 
 exports[`Cypher works 1`] = `"pending"`;
 
+exports[`Cypher works 2`] = `"pending"`;
+
 exports[`CypherEditor works 1`] = `
+<div
+  className="ReactCodeMirror"
+/>
+`;
+
+exports[`CypherEditor works 2`] = `
 <div
   className="ReactCodeMirror"
 />
@@ -259,7 +516,11 @@ exports[`CypherEditor works 1`] = `
 
 exports[`DesktopIntegration works 1`] = `null`;
 
+exports[`DesktopIntegration works 2`] = `null`;
+
 exports[`DriverProvider works 1`] = `"Hello"`;
+
+exports[`DriverProvider works 2`] = `"Hello"`;
 
 exports[`GraphAppBase works 1`] = `
 <div>
@@ -267,7 +528,19 @@ exports[`GraphAppBase works 1`] = `
 </div>
 `;
 
+exports[`GraphAppBase works 2`] = `
+<div>
+  Hello
+</div>
+`;
+
 exports[`Render works 1`] = `
+<p>
+  Hello
+</p>
+`;
+
+exports[`Render works 2`] = `
 <p>
   Hello
 </p>

--- a/test_package/react/package.test.js
+++ b/test_package/react/package.test.js
@@ -1,7 +1,7 @@
 import React from "react";
 import TestRenderer from "react-test-renderer";
 
-// Package exports ui/
+// Package exports components/xxx
 import { Render } from "../../dist/components/Render";
 import { AsciiTable } from "../../dist/components/AsciiTable";
 import { Chart } from "../../dist/components/Chart";
@@ -11,72 +11,137 @@ import { DriverProvider } from "../../dist/components/DriverProvider";
 import { CypherEditor } from "../../dist/components/Editor";
 import { GraphAppBase } from "../../dist/components/GraphAppBase";
 
+// Package exports components/
+import {
+  Render as RenderC,
+  AsciiTable as AsciiTableC,
+  Chart as ChartC,
+  Cypher as CypherC,
+  DesktopIntegration as DesktopIntegrationC,
+  DriverProvider as DriverProviderC,
+  CypherEditor as CypherEditorC,
+  GraphAppBase as GraphAppBaseC
+} from "../../dist/components";
+
 // Package exports lib/
 import { shallowEqual } from "../../dist/lib/utils";
 
-// components/
+// components
 test("Render works", () => {
-  const out = TestRenderer.create(
+  const cs = [
     <Render if={true}>
       <p>Hello</p>
-    </Render>
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+    </Render>,
+    <RenderC if={true}>
+      <p>Hello</p>
+    </RenderC>
+  ];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("AsciiTable works", () => {
   const data = [["x"], ["y"]];
-  const out = TestRenderer.create(<AsciiTable data={data} />);
-  expect(out.toJSON()).toMatchSnapshot();
+  const cs = [<AsciiTable data={data} />, <AsciiTableC data={data} />];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("Chart works", () => {
   const data = [{ label: "Used", value: 30 }, { label: "Free", value: 20 }];
-  const out = TestRenderer.create(
+  const cs = [
     <Chart
       data={data}
       title="Static circular data"
       chartType="doughnut"
       type="json"
+    />,
+    <ChartC
+      data={data}
+      title="Static circular data"
+      chartType="doughnut"
+      type="json"
     />
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  ];
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("CypherEditor works", () => {
-  const out = TestRenderer.create(<CypherEditor />);
-  expect(out.toJSON()).toMatchSnapshot();
+  const cs = [<CypherEditor />, <CypherEditorC />];
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("Cypher works", () => {
-  const out = TestRenderer.create(
+  const cs = [
     <Cypher
       driver={resolvingDriver(0, "no!")}
       query="RETURN rand() as n"
       render={({ pending, error, result, tick }) => {
         return pending ? "pending" : error ? error.message : result;
       }}
+    />,
+    <CypherC
+      driver={resolvingDriver(0, "no!")}
+      query="RETURN rand() as n"
+      render={({ pending, error, result, tick }) => {
+        return pending ? "pending" : error ? error.message : result;
+      }}
     />
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  ];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("DesktopIntegration works", () => {
-  const out = TestRenderer.create(
-    <DesktopIntegration integrationPoint={true} />
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  const cs = [
+    <DesktopIntegration integrationPoint={true} />,
+    <DesktopIntegrationC integrationPoint={true} />
+  ];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("DriverProvider works", () => {
-  const out = TestRenderer.create(
-    <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  const cs = [
+    <DriverProvider driver={resolvingDriver(0, "yes")}>Hello</DriverProvider>,
+    <DriverProviderC driver={resolvingDriver(0, "yes")}>Hello</DriverProviderC>
+  ];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 test("GraphAppBase works", () => {
-  const out = TestRenderer.create(
+  const cs = [
     <GraphAppBase
       integrationPoint={null}
       render={() => "Hello"}
       driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
+    />,
+    <GraphAppBaseC
+      integrationPoint={null}
+      render={() => "Hello"}
+      driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
     />
-  );
-  expect(out.toJSON()).toMatchSnapshot();
+  ];
+
+  cs.forEach(c => {
+    const out = TestRenderer.create(c);
+    expect(out.toJSON()).toMatchSnapshot();
+  });
 });
 
 // Utils
@@ -85,6 +150,7 @@ test("shallowEqual works", () => {
 });
 
 // Helpers
+
 const sleep = (secs, shouldResolve = true, message) =>
   new Promise((resolve, reject) => {
     setTimeout(


### PR DESCRIPTION
Allows for imports like:

`import { Cypher } from ‘graph-app-kit/components`.

I'll need to verify that unused code in that bundle are identified by webpack to reduce final app size.