### PR TITLE
Add Sidebar component

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ import { DriverProvider } from "graph-app-kit/components/DriverProvider";
 import { Render } from "graph-app-kit/components/Render";
 import { Chart } from "graph-app-kit/components/Chart";
 import { CypherEditor } from "graph-app-kit/components/CypherEditor";
+import { Sidebar } from "graph-app-kit/component/Sidebar";
 ```
 
 ## Component playground / library

--- a/config/jest.config.base.js
+++ b/config/jest.config.base.js
@@ -12,7 +12,10 @@ module.exports = {
   transformIgnorePatterns: ["[/\\\\]node_modules[/\\\\].+\\.(js|jsx)$"],
   moduleNameMapper: {
     "^react-native$": "react-native-web",
-    "^graph-app-kit(.*)": "<rootDir>/src$1"
+    "^graph-app-kit(.*)": "<rootDir>/src$1",
+    "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+      "<rootDir>/__mocks__/fileMock.js",
+    "\\.(css|less)$": "identity-obj-proxy"
   },
   moduleFileExtensions: ["web.js", "js", "json", "web.jsx", "jsx", "node"]
 };

--- a/config/kit_exports.js
+++ b/config/kit_exports.js
@@ -17,6 +17,7 @@ module.exports = {
   "components/DriverProvider": resolveApp("src/components/DriverProvider"),
   "components/GraphAppBase": resolveApp("src/components/GraphAppBase"),
   "components/Editor": resolveApp("src/components/Editor"),
+  "components/Sidebar": resolveApp("src/components/Sidebar"),
   "lib/utils": resolveApp("src/lib/utils"),
   "lib/boltTransforms": resolveApp("src/lib/boltTransforms")
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "graph-app-kit",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "harmony-reflect": {
+      "version": "1.5.1",
+      "resolved":
+        "https://neo.jfrog.io/neo/api/npm/npm/harmony-reflect/-/harmony-reflect-1.5.1.tgz",
+      "integrity": "sha1-tUymF7AMyK71Wbuxez2FQx3H4yk=",
+      "dev": true
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved":
+        "https://neo.jfrog.io/neo/api/npm/npm/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "1.5.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
     "build": "node scripts/build.js",
     "test": "CI=true npm run dev",
     "test:package": "yarn build && yarn test:react && yarn test:preact",
-    "test:react": "CI=true node scripts/test.js --config=config/jest.config.base.js --env=jsdom test_package/react",
-    "test:preact": "CI=true node scripts/test.js --config=config/jest.config.preact.js --env=jsdom test_package/preact",
+    "test:react":
+      "CI=true node scripts/test.js --config=config/jest.config.base.js --env=jsdom test_package/react",
+    "test:preact":
+      "CI=true node scripts/test.js --config=config/jest.config.preact.js --env=jsdom test_package/preact",
     "test:all": "yarn test && yarn test:package",
-    "dev": "node scripts/test.js --config=config/jest.config.base.js --env=jsdom src",
+    "dev":
+      "node  scripts/test.js --config=config/jest.config.base.js --env=jsdom src",
     "lint": "eslint --fix --ext .js --ext .jsx src",
     "precommit": "lint-staged",
     "prepare-dist": "node scripts/release.js",
@@ -20,10 +23,7 @@
     "start": "node scripts/start.js"
   },
   "lint-staged": {
-    "*.{js,jsx,json,css}": [
-      "prettier --write",
-      "git add"
-    ]
+    "*.{js,jsx,json,css}": ["prettier --write", "git add"]
   },
   "license": "Apache-2.0",
   "devDependencies": {
@@ -51,6 +51,7 @@
     "file-loader": "^1.1.5",
     "html-webpack-plugin": "^2.30.1",
     "husky": "^0.14.3",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^20.0.4",
     "jest-cli": "^21.2.1",
     "lint-staged": "^4.2.3",
@@ -83,9 +84,7 @@
     "react-dom": "^16.0.0"
   },
   "babel": {
-    "presets": [
-      "react-app"
-    ]
+    "presets": ["react-app"]
   },
   "dependencies": {
     "@data-ui/radial-chart": "0.0.11",

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -1,7 +1,7 @@
 Component that creates a sidebar that allows configuration of buttons with
 content that is shown in a animated 'drawer'
 
-### Simple un-controlled component usage:
+#### Simple un-controlled component usage:
 
 ```javascript
 <Sidebar

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -1,4 +1,7 @@
-Conditinally render child component.
+Component that create a sidebar that allows configuration of buttons with
+content that is shown in a animated 'drawer'
+
+### Basic usage:
 
 ```javascript
 <Sidebar
@@ -6,22 +9,62 @@ Conditinally render child component.
     {
       name: "Tick",
       title: "Tick button",
-      icon: isOpen => <div>{"\u2714"}</div>,
-      content: <span>Tick</span>
+      icon: <div>{"\u2714"}</div>,
+      drawerdrawerContent: <span>Tick</span>
     },
     {
       name: "Cross",
       title: "Cross button",
-      icon: isOpen => <div>{"\u2716"}</div>,
-      content: <span>Cross</span>
+      icon: <div>{"\u2716"}</div>,
+      drawerContent: <span>Cross</span>
     }
   ]}
   bottomNavItems={[
     {
       name: "About",
       title: "About",
-      icon: isOpen => null,
-      content: <span>Abouta</span>
+      icon: <div>{"\u2716"}</div>,
+      drawerContent: <span>About</span>
+    }
+  ]}
+/>;
+```
+
+### Advanced usage:
+
+Custom button rendering
+
+```javascript
+<Sidebar
+  openDrawer="Tick"
+  _renderItem={item => {
+    const { name, title, icon, isOpen } = item;
+    return (
+      <div title={title}>
+        {isOpen ? "Open" : name}
+        {icon}
+      </div>
+    );
+  }}
+  topNavItems={[
+    {
+      name: "Tick",
+      title: "Tick button",
+      icon: <div>{"\u2714"}</div>,
+      drawerContent: <span>Tick</span>
+    },
+    {
+      name: "Cross",
+      title: "Cross button",
+      icon: <div>{"\u2716"}</div>,
+      drawerContent: <span>Cross</span>
+    }
+  ]}
+  bottomNavItems={[
+    {
+      name: "About",
+      title: "About",
+      drawerContent: <span>About</span>
     }
   ]}
 />;

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -33,16 +33,28 @@ Will read in `openDrawer` prop and react to any changes to the prop. The `onChan
 
 ```javascript
 <Sidebar
-onChange={(name) => console.log("Name of open drawer:", name)}
-openDrawer='a'
-render={({ selected, applySelectedClass }) => (
+  onChange={name => console.log("Name of open drawer:", name)}
+  openDrawer="a"
+  render={({ selected, applySelectedClass }) => (
     <Sidebar.Container>
       <Sidebar.Top>
         <Sidebar.Item name="a">
           <Sidebar.Button className={applySelectedClass("selected top bar")}>
-            B1
+            <div
+              style={{
+                background: "blue",
+                color: "white",
+                padding: 0,
+                margin: 0
+              }}
+            >
+              Custom Button
+            </div>
           </Sidebar.Button>
-          <Sidebar.Content>C1</Sidebar.Content>
+          <Sidebar.Content>
+            <div>{selected} drawer </div>
+            <button>button</button>
+          </Sidebar.Content>
         </Sidebar.Item>
       </Sidebar.Top>
       <Sidebar.Bottom>
@@ -54,4 +66,5 @@ render={({ selected, applySelectedClass }) => (
     </Sidebar.Container>
   )}
 />;
+
 ```

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -29,7 +29,9 @@ content that is shown in a animated 'drawer'
 
 #### Controlled component usage:
 
-Will read in `openDrawer` prop and react to any changes to the prop. The `onChange` callback will be triggered when a sidebar button is clicked. If `defaultOpenDrawer` prop is set then only that content will be shown.
+Will read in `openDrawer` prop and react to any changes to the prop. The
+`onChange` callback will be triggered when a sidebar button is clicked. If
+`defaultOpenDrawer` prop is set then only that content will be shown.
 
 ```javascript
 <Sidebar
@@ -66,5 +68,4 @@ Will read in `openDrawer` prop and react to any changes to the prop. The `onChan
     </Sidebar.Container>
   )}
 />;
-
 ```

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -1,0 +1,20 @@
+Conditinally render child component.
+
+```javascript
+<Sidebar
+  topNavItems={[
+    {
+      name: "Tick",
+      title: "Tick button",
+      icon: isOpen => <span>{"\u2714"}</span>,
+      content: <span>Tick</span>
+    },
+    {
+      name: "Cross",
+      title: "Cross button",
+      icon: isOpen => <span>{"\u2716"}</span>,
+      content: <span>Cross</span>
+    }
+  ]}
+/>;
+```

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -5,6 +5,33 @@ content that is shown in a animated 'drawer'
 
 ```javascript
 <Sidebar
+  // onChange
+  // openDrawer
+  // defaultOpenDrawer
+  // contentWidth
+  render={({ selected, applySelectedClass }) => (
+    <Sidebar.Container>
+      <Sidebar.Top>
+        <Sidebar.Item name="a">
+          <Sidebar.Button className={applySelectedClass("selected top bar")}>
+            B1
+          </Sidebar.Button>
+          <Sidebar.Content>C1</Sidebar.Content>
+        </Sidebar.Item>
+      </Sidebar.Top>
+      <Sidebar.Bottom>
+        <Sidebar.Item name="b">
+          <Sidebar.Button>B2</Sidebar.Button>
+          <Sidebar.Content>C2</Sidebar.Content>
+        </Sidebar.Item>
+      </Sidebar.Bottom>
+    </Sidebar.Container>
+  )}
+/>;
+```
+
+<!-- ```javascript
+<Sidebar
   topNavItems={[
     {
       name: "Tick",
@@ -68,4 +95,4 @@ Custom button rendering
     }
   ]}
 />;
-```
+``` -->

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -1,14 +1,11 @@
-Component that create a sidebar that allows configuration of buttons with
+Component that creates a sidebar that allows configuration of buttons with
 content that is shown in a animated 'drawer'
 
-### Basic usage:
+### Simple un-controlled component usage:
 
 ```javascript
 <Sidebar
-  // onChange
-  // openDrawer
-  // defaultOpenDrawer
-  // contentWidth
+  contentWidth="300px"
   render={({ selected, applySelectedClass }) => (
     <Sidebar.Container>
       <Sidebar.Top>
@@ -30,69 +27,31 @@ content that is shown in a animated 'drawer'
 />;
 ```
 
-<!-- ```javascript
-<Sidebar
-  topNavItems={[
-    {
-      name: "Tick",
-      title: "Tick button",
-      icon: <div>{"\u2714"}</div>,
-      drawerContent: <span>Tick</span>
-    },
-    {
-      name: "Cross",
-      title: "Cross button",
-      icon: <div>{"\u2716"}</div>,
-      drawerContent: <span>Cross</span>
-    }
-  ]}
-  bottomNavItems={[
-    {
-      name: "About",
-      title: "About",
-      icon: <div>{"\u2716"}</div>,
-      drawerContent: <span>About</span>
-    }
-  ]}
-/>;
-```
+#### Controlled component usage:
 
-### Advanced usage:
-
-Custom button rendering
+Will read in `openDrawer` prop and react to any changes to the prop. The `onChange` callback will be triggered when a sidebar button is clicked. If `defaultOpenDrawer` prop is set then only that content will be shown.
 
 ```javascript
 <Sidebar
-  openDrawer="Tick"
-  _renderItem={item => {
-    const { name, title, icon, isOpen } = item;
-    return (
-      <div title={title}>
-        {isOpen ? "Open" : name}
-        {icon}
-      </div>
-    );
-  }}
-  topNavItems={[
-    {
-      name: "Tick",
-      title: "Tick button",
-      icon: <div>{"\u2714"}</div>,
-      drawerContent: <span>Tick</span>
-    },
-    {
-      name: "Cross",
-      title: "Cross button",
-      icon: <div>{"\u2716"}</div>,
-      drawerContent: <span>Cross</span>
-    }
-  ]}
-  bottomNavItems={[
-    {
-      name: "About",
-      title: "About",
-      drawerContent: <span>About</span>
-    }
-  ]}
+onChange={(name) => console.log("Name of open drawer:", name)}
+openDrawer='a'
+render={({ selected, applySelectedClass }) => (
+    <Sidebar.Container>
+      <Sidebar.Top>
+        <Sidebar.Item name="a">
+          <Sidebar.Button className={applySelectedClass("selected top bar")}>
+            B1
+          </Sidebar.Button>
+          <Sidebar.Content>C1</Sidebar.Content>
+        </Sidebar.Item>
+      </Sidebar.Top>
+      <Sidebar.Bottom>
+        <Sidebar.Item name="b">
+          <Sidebar.Button>B2</Sidebar.Button>
+          <Sidebar.Content>C2</Sidebar.Content>
+        </Sidebar.Item>
+      </Sidebar.Bottom>
+    </Sidebar.Container>
+  )}
 />;
-``` -->
+```

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -10,7 +10,7 @@ content that is shown in a animated 'drawer'
       name: "Tick",
       title: "Tick button",
       icon: <div>{"\u2714"}</div>,
-      drawerdrawerContent: <span>Tick</span>
+      drawerContent: <span>Tick</span>
     },
     {
       name: "Cross",

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -6,14 +6,22 @@ Conditinally render child component.
     {
       name: "Tick",
       title: "Tick button",
-      icon: isOpen => <span>{"\u2714"}</span>,
+      icon: isOpen => <div>{"\u2714"}</div>,
       content: <span>Tick</span>
     },
     {
       name: "Cross",
       title: "Cross button",
-      icon: isOpen => <span>{"\u2716"}</span>,
+      icon: isOpen => <div>{"\u2716"}</div>,
       content: <span>Cross</span>
+    }
+  ]}
+  bottomNavItems={[
+    {
+      name: "About",
+      title: "About",
+      icon: isOpen => null,
+      content: <span>Abouta</span>
     }
   ]}
 />;

--- a/src/components/Sidebar/README.md
+++ b/src/components/Sidebar/README.md
@@ -6,13 +6,11 @@ content that is shown in a animated 'drawer'
 ```javascript
 <Sidebar
   contentWidth="300px"
-  render={({ selected, applySelectedClass }) => (
+  render={({ selected }) => (
     <Sidebar.Container>
       <Sidebar.Top>
         <Sidebar.Item name="a">
-          <Sidebar.Button className={applySelectedClass("selected top bar")}>
-            B1
-          </Sidebar.Button>
+          <Sidebar.Button>B1</Sidebar.Button>
           <Sidebar.Content>C1</Sidebar.Content>
         </Sidebar.Item>
       </Sidebar.Top>
@@ -37,11 +35,11 @@ Will read in `openDrawer` prop and react to any changes to the prop. The
 <Sidebar
   onChange={name => console.log("Name of open drawer:", name)}
   openDrawer="a"
-  render={({ selected, applySelectedClass }) => (
+  render={({ selected }) => (
     <Sidebar.Container>
       <Sidebar.Top>
         <Sidebar.Item name="a">
-          <Sidebar.Button className={applySelectedClass("selected top bar")}>
+          <Sidebar.Button>
             <div
               style={{
                 background: "blue",

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,0 +1,143 @@
+import React, { Component } from "react";
+import * as PropTypes from "prop-types";
+
+const Closing = "CLOSING";
+const Closed = "CLOSED";
+const Open = "OPEN";
+const Opening = "OPENING";
+
+export class Sidebar extends Component {
+  constructor(props) {
+    super(props);
+    this._onTransitionEnd = this.onTransitionEnd.bind(this);
+    this.drawerContent = null;
+    this.state = {
+      openDrawer: props.openDrawer,
+      transitionState: Closed
+    };
+  }
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.openDrawer !== this.props.openDrawer) {
+      this.props.drawerHasChanged(this.state.openDrawer);
+      var newState = {};
+      if (nextProps.openDrawer) {
+        this.drawerContent = nextProps.openDrawer;
+        if (
+          this.state.transitionState === Closed ||
+          this.state.transitionState === Closing
+        ) {
+          newState.transitionState = Opening;
+        }
+      } else {
+        this.drawerContent = "";
+        if (
+          this.state.transitionState === Open ||
+          this.state.transitionState === Opening
+        ) {
+          newState.transitionState = Closing;
+        }
+      }
+      this.setState(newState);
+    }
+  }
+
+  onTransitionEnd() {
+    if (this.transitionState === Closing) {
+      this.setState({
+        transitionState: Closed,
+        drawerContent: null
+      });
+    }
+    if (this.transitionState === Opening) {
+      this.setState({
+        transitionState: Open
+      });
+    }
+  }
+
+  buildNavList = (list, selected) => {
+    return list.map((item, index) => {
+      const isOpen = item.name.toLowerCase() === selected;
+      const icon = item.icon(isOpen);
+      return (
+        <div
+          onClick={() => {
+            const openDrawer =
+              item.name === this.state.openDrawer ? null : item.name;
+            this.setState({ openDrawer });
+          }}
+          title={item.title}
+          data-test-id={"drawer" + item.name}
+          key={index}
+        >
+          <span name={item.name}>{icon}</span>
+        </div>
+      );
+    });
+  };
+
+  render() {
+    const { onNavClick, topNavItems, bottomNavItems } = this.props;
+    const getContentToShow = openDrawer => {
+      if (openDrawer) {
+        const filteredList = [...topNavItems, ...bottomNavItems].filter(
+          item => {
+            return item.name === openDrawer;
+          }
+        );
+        return filteredList[0].content;
+      }
+      return null;
+    };
+    const renderedtopNavItemsList = this.buildNavList(
+      topNavItems,
+      this.drawerContent
+    );
+    const renderedbottomNavItemsList = this.buildNavList(
+      bottomNavItems,
+      this.drawerContent
+    );
+
+    return (
+      <div>
+        <div>
+          <div>{renderedtopNavItemsList}</div>
+          <div>{renderedbottomNavItemsList}</div>
+        </div>
+        <div
+          open={
+            this.state.transitionState === Open ||
+            this.state.transitionState === Opening
+          }
+          ref={ref => {
+            if (ref) {
+              // Remove old listeners so we don't get multiple callbacks.
+              // This function is called more than once with same html element
+              ref.removeEventListener("transitionend", this._onTransitionEnd);
+              ref.addEventListener("transitionend", this._onTransitionEnd);
+            }
+          }}
+        >
+          {getContentToShow(this.state.openDrawer)}
+        </div>
+      </div>
+    );
+  }
+}
+
+Sidebar.propTypes = {
+  openDrawer: PropTypes.string,
+  onNavClick: PropTypes.func,
+  topNavItems: PropTypes.array,
+  bottomNavItems: PropTypes.array,
+  drawerHasChanged: PropTypes.func
+};
+
+Sidebar.defaultProps = {
+  openDrawer: null,
+  onNavClick: () => {},
+  topNavItems: [],
+  bottomNavItems: []
+};
+
+export default Sidebar;

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -23,7 +23,6 @@ export class Sidebar extends Component {
   componentWillReceiveProps(nextProps) {
     if (nextProps.openDrawer !== this.state.openDrawer) {
       this.props.drawerHasChanged(this.state.openDrawer);
-      this.setState(newState);
     }
   }
 

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -27,13 +27,22 @@ class Sidebar extends Component {
     };
   }
   selectDrawer = (name, drawerContent) => {
+    if (this.props.defaultOpenDrawer) {
+      return this.setState({
+        openDrawer: this.props.defaultOpenDrawer,
+        drawerContent:
+          name === this.props.defaultOpenDrawer
+            ? drawerContent
+            : this.state.drawerContent
+      });
+    }
     if (name !== this.state.openDrawer) {
-      this.setState({
+      return this.setState({
         openDrawer: name,
         drawerContent
       });
     } else {
-      this.setState({ ...this.initalState });
+      return this.setState({ ...this.initalState });
     }
   };
   render() {
@@ -43,13 +52,15 @@ class Sidebar extends Component {
         {...this.props}
         openDrawer={this.state.openDrawer}
         drawerContent={this.state.drawerContent}
+        contentWidth={this.props.contentWidth}
       />
     );
   }
 }
 
 const SidebarComponent = (props, context) => {
-  const applySelectedClass = () => {};
+  const applySelectedClass = classNames => name =>
+    props.openDrawer === name ? { className: classNames } : {};
   return (
     <div>
       {props.render({
@@ -67,6 +78,7 @@ const SidebarComponent = (props, context) => {
           animation="push"
           visible={!!props.openDrawer}
           vertical
+          style={{ width: props.contentWidth }}
         >
           <SemanticSidebar.Pusher>
             <Segment basic>{props.drawerContent}</Segment>

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -14,28 +14,34 @@ import {
 class Sidebar extends Component {
   constructor(props, context) {
     super(props, context);
-    this.initalState = { openDrawer: null, drawerContent: null };
+    this.initalState = {
+      openDrawer: null,
+      drawerContent: null,
+      defaultOpenDrawer: null
+    };
     this.state = {
       ...this.initalState,
-      openDrawer: props.defaultOpenDrawer || props.openDrawer || null
+      openDrawer: props.openDrawer,
+      defaultOpenDrawer: props.defaultOpenDrawer
     };
   }
   getChildContext() {
     return {
       openDrawer: this.state.openDrawer,
-      selectDrawer: this.selectDrawer
+      selectDrawer: this.selectDrawer,
+      defaultOpenDrawer: this.props.defaultOpenDrawer
     };
   }
   selectDrawer = (name, drawerContent) => {
-    if (this.props.defaultOpenDrawer) {
-      return this.setState({
-        openDrawer: this.props.defaultOpenDrawer,
-        drawerContent:
-          name === this.props.defaultOpenDrawer
-            ? drawerContent
-            : this.state.drawerContent
-      });
-    }
+    // if (this.props.defaultOpenDrawer) {
+    //   return this.setState({
+    //     openDrawer: this.props.defaultOpenDrawer,
+    //     drawerContent:
+    //       name === this.props.defaultOpenDrawer
+    //         ? drawerContent
+    //         : this.state.drawerContent
+    //   });
+    // }
     if (name !== this.state.openDrawer) {
       return this.setState({
         openDrawer: name,
@@ -92,12 +98,14 @@ const SidebarComponent = (props, context) => {
 
 SidebarComponent.contextTypes = {
   selected: PropTypes.string,
-  selectDrawer: PropTypes.func
+  selectDrawer: PropTypes.func,
+  defaultOpenDrawer: PropTypes.string
 };
 
 Sidebar.childContextTypes = {
   openDrawer: PropTypes.string,
-  selectDrawer: PropTypes.func
+  selectDrawer: PropTypes.func,
+  defaultOpenDrawer: PropTypes.string
 };
 
 Sidebar.propTypes = {

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,15 +1,6 @@
 import React, { Component, Children } from "react";
 import * as PropTypes from "prop-types";
-import {
-  Grid,
-  Sidebar as SemanticSidebar,
-  Segment,
-  Button,
-  Menu,
-  Image,
-  Icon,
-  Header
-} from "semantic-ui-react";
+import { Sidebar as SemanticSidebar, Segment, Menu } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
 import {
   SidebarContainer,

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,6 +1,18 @@
 import React, { Component } from "react";
 import * as PropTypes from "prop-types";
 
+import {
+  Grid,
+  Sidebar as SemanticSidebar,
+  Segment,
+  Button,
+  Menu,
+  Image,
+  Icon,
+  Header
+} from "semantic-ui-react";
+import "semantic-ui-css/semantic.min.css";
+
 const Closing = "CLOSING";
 const Closed = "CLOSED";
 const Open = "OPEN";
@@ -60,7 +72,8 @@ export class Sidebar extends Component {
       const isOpen = item.name.toLowerCase() === selected;
       const icon = item.icon(isOpen);
       return (
-        <div
+        <Menu.Item
+          name={item.name}
           onClick={() => {
             const openDrawer =
               item.name === this.state.openDrawer ? null : item.name;
@@ -69,23 +82,19 @@ export class Sidebar extends Component {
           title={item.title}
           data-test-id={"drawer" + item.name}
           key={index}
-        >
-          <span name={item.name}>{icon}</span>
-        </div>
+          icon={icon}
+        />
       );
     });
   };
 
   render() {
-    const { onNavClick, topNavItems, bottomNavItems } = this.props;
+    const { onNavClick, topNavItems, bottomNavItems, minHeight } = this.props;
     const getContentToShow = openDrawer => {
       if (openDrawer) {
-        const filteredList = [...topNavItems, ...bottomNavItems].filter(
-          item => {
-            return item.name === openDrawer;
-          }
-        );
-        return filteredList[0].content;
+        return [...topNavItems, ...bottomNavItems].find(item => {
+          return item.name === openDrawer;
+        }).content;
       }
       return null;
     };
@@ -100,25 +109,42 @@ export class Sidebar extends Component {
 
     return (
       <div>
-        <div>
-          <div>{renderedtopNavItemsList}</div>
-          <div>{renderedbottomNavItemsList}</div>
-        </div>
         <div
-          open={
-            this.state.transitionState === Open ||
-            this.state.transitionState === Opening
-          }
-          ref={ref => {
-            if (ref) {
-              // Remove old listeners so we don't get multiple callbacks.
-              // This function is called more than once with same html element
-              ref.removeEventListener("transitionend", this._onTransitionEnd);
-              ref.addEventListener("transitionend", this._onTransitionEnd);
-            }
+          style={{
+            width: "86px",
+            float: "left",
+            minHeight: this.props.fullscreenHeight ? "100vh" : "400px",
+            maxHeight: this.props.fullscreenHeight ? "100vh" : "auto"
           }}
         >
-          {getContentToShow(this.state.openDrawer)}
+          <Menu vertical fitted="horizontally" icon="labeled">
+            {renderedtopNavItemsList}
+          </Menu>
+          <Menu vertical fitted="horizontally" icon="labeled">
+            {renderedbottomNavItemsList}
+          </Menu>
+        </div>
+        <div>
+          <SemanticSidebar.Pushable
+            style={{
+              minHeight: this.props.fullscreenHeight ? "100vh" : "400px",
+              maxHeight: this.props.fullscreenHeight ? "100vh" : "auto"
+            }}
+          >
+            <SemanticSidebar
+              as={Menu}
+              animation="push"
+              width="thin"
+              visible={!!this.state.openDrawer}
+              vertical
+            >
+              <SemanticSidebar.Pusher>
+                <Segment basic>
+                  {getContentToShow(this.state.openDrawer)}
+                </Segment>
+              </SemanticSidebar.Pusher>
+            </SemanticSidebar>
+          </SemanticSidebar.Pushable>
         </div>
       </div>
     );
@@ -130,7 +156,8 @@ Sidebar.propTypes = {
   onNavClick: PropTypes.func,
   topNavItems: PropTypes.array,
   bottomNavItems: PropTypes.array,
-  drawerHasChanged: PropTypes.func
+  drawerHasChanged: PropTypes.func,
+  fullscreenHeight: PropTypes.bool
 };
 
 Sidebar.defaultProps = {

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -58,7 +58,6 @@ class Sidebar extends Component {
     }
   }
   render() {
-    debugger;
     this.props.onChange(this.state.openDrawer);
     return (
       <SidebarComponent

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -1,4 +1,4 @@
-import React, { Component, Children } from "react";
+import React, { Component } from "react";
 import * as PropTypes from "prop-types";
 import { Sidebar as SemanticSidebar, Segment, Menu } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
@@ -14,14 +14,34 @@ import {
 class Sidebar extends Component {
   constructor(props, context) {
     super(props, context);
+    this.selectDrawer = updatedItem => {
+      if (updatedItem.name !== this.state.openDrawer.name) {
+        return this.setState({
+          openDrawer: { ...updatedItem }
+        });
+      }
+      if (!this.state.openDrawer.content) {
+        return this.setState({
+          openDrawer: { ...this.state.openDrawer, content: updatedItem.content }
+        });
+      }
+
+      if (
+        updatedItem.name === this.state.openDrawer.name &&
+        this.state.openDrawer.content
+      ) {
+        return this.setState({ ...this.initalState });
+      }
+    };
     this.initalState = {
-      openDrawer: null,
-      drawerContent: null,
-      defaultOpenDrawer: null
+      openDrawer: {
+        name: null,
+        content: null
+      }
     };
     this.state = {
       ...this.initalState,
-      openDrawer: props.openDrawer,
+      openDrawer: { name: props.openDrawer },
       defaultOpenDrawer: props.defaultOpenDrawer
     };
   }
@@ -32,32 +52,19 @@ class Sidebar extends Component {
       defaultOpenDrawer: this.props.defaultOpenDrawer
     };
   }
-  selectDrawer = (name, drawerContent) => {
-    // if (this.props.defaultOpenDrawer) {
-    //   return this.setState({
-    //     openDrawer: this.props.defaultOpenDrawer,
-    //     drawerContent:
-    //       name === this.props.defaultOpenDrawer
-    //         ? drawerContent
-    //         : this.state.drawerContent
-    //   });
-    // }
-    if (name !== this.state.openDrawer) {
-      return this.setState({
-        openDrawer: name,
-        drawerContent
-      });
-    } else {
-      return this.setState({ ...this.initalState });
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.openDrawer !== this.props.openDrawer) {
+      this.setState({ ...this.initalState, openDrawer: nextProps.openDrawer });
     }
-  };
+  }
   render() {
+    debugger;
     this.props.onChange(this.state.openDrawer);
     return (
       <SidebarComponent
         {...this.props}
-        openDrawer={this.state.openDrawer}
-        drawerContent={this.state.drawerContent}
+        openDrawer={this.state.openDrawer.name}
+        drawerContent={this.state.openDrawer.content}
         contentWidth={this.props.contentWidth}
       />
     );
@@ -75,7 +82,7 @@ const SidebarComponent = (props, context) => {
       })}
       <SemanticSidebar.Pushable
         style={{
-          minHeight: props.fullscreenHeight ? "100vh" : "400px",
+          minHeight: props.fullscreenHeight ? "100vh" : "300px",
           maxHeight: props.fullscreenHeight ? "100vh" : "auto"
         }}
       >
@@ -103,7 +110,7 @@ SidebarComponent.contextTypes = {
 };
 
 Sidebar.childContextTypes = {
-  openDrawer: PropTypes.string,
+  openDrawer: PropTypes.object,
   selectDrawer: PropTypes.func,
   defaultOpenDrawer: PropTypes.string
 };

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -128,7 +128,7 @@ Sidebar.defaultProps = {
   onChange: () => {},
   openDrawer: null,
   defaultOpenDrawer: null,
-  contentWidth: undefined,
+  contentWidth: "auto",
   fullscreenHeight: false,
   render: () => {}
 };

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -36,11 +36,8 @@ class Sidebar extends Component {
       this.setState({ ...this.initalState });
     }
   };
-  componentWillReceiveProps(nextProps) {
-    this.setState({ openDrawer: nextProps.openDrawer }),
-      this.props.drawerHasChanged(this.state.openDrawer);
-  }
   render() {
+    this.props.onChange(this.state.openDrawer);
     return (
       <SidebarComponent
         {...this.props}
@@ -52,11 +49,12 @@ class Sidebar extends Component {
 }
 
 const SidebarComponent = (props, context) => {
+  const applySelectedClass = () => {};
   return (
     <div>
       {props.render({
         selected: props.openDrawer,
-        applySelectedClass: () => {}
+        applySelectedClass
       })}
       <SemanticSidebar.Pushable
         style={{

--- a/src/components/Sidebar/Sidebar.js
+++ b/src/components/Sidebar/Sidebar.js
@@ -116,13 +116,22 @@ export class Sidebar extends Component {
 }
 
 Sidebar.propTypes = {
-  _renderItem: PropTypes.func,
   openDrawer: PropTypes.string,
   onNavClick: PropTypes.func,
   topNavItems: PropTypes.array,
   bottomNavItems: PropTypes.array,
   drawerHasChanged: PropTypes.func,
-  fullscreenHeight: PropTypes.bool
+  fullscreenHeight: PropTypes.bool,
+  /** Advanced usage. Calls the function with an object* that can be used for custom button rendering
+   *
+   * \* {
+  name, //from *NavItem
+  title, //from *NavItem
+  icon, //from *NavItem
+  isOpen //bool that returns true when the NavItem's drawerContent is visible
+};
+   */
+  _renderItem: PropTypes.func
 };
 
 Sidebar.defaultProps = {

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -1,0 +1,88 @@
+import React, { Component, Children } from "react";
+import * as PropTypes from "prop-types";
+import {
+  Grid,
+  Sidebar as SemanticSidebar,
+  Segment,
+  Button,
+  Menu,
+  Image,
+  Icon,
+  Header
+} from "semantic-ui-react";
+import "semantic-ui-css/semantic.min.css";
+
+export const SidebarContainer = ({ fullscreenHeight, children }) => (
+  <div
+    style={{
+      width: "86px",
+      float: "left",
+      minHeight: fullscreenHeight ? "100vh" : "400px",
+      maxHeight: fullscreenHeight ? "100vh" : "auto",
+      display: "flex",
+      flexDirection: "column"
+    }}
+  >
+    {children}
+  </div>
+);
+
+const SidebarItem = ({ children, name }, context) => {
+  const filteredSidebarButtonChildren = Children.map(children, child => {
+    return child.type && child.type.name === "SidebarButton" ? child : null;
+  }).filter(_ => !!_);
+  const drawerContent = Children.map(children, child => {
+    return child.type && child.type.name === "SidebarContent" ? child : null;
+  }).filter(_ => !!_);
+  return (
+    <Menu.Item
+      onClick={() => {
+        context.selectDrawer(name, drawerContent);
+      }}
+    >
+      {filteredSidebarButtonChildren}
+    </Menu.Item>
+  );
+};
+
+SidebarItem.contextTypes = {
+  selected: PropTypes.string,
+  selectDrawer: PropTypes.func
+};
+
+export { SidebarItem };
+
+export const SidebarTop = ({ children, ...rest }) => {
+  const filteredChildren = Children.map(children, child => {
+    return child.type && child.type.prototype === SidebarItem.prototype
+      ? child
+      : null;
+  }).filter(_ => !!_);
+  return (
+    <Menu vertical fitted="horizontally" icon="labeled" {...rest}>
+      {filteredChildren}
+    </Menu>
+  );
+};
+
+export const SidebarBottom = ({ children, ...rest }) => {
+  const filteredChildren = Children.map(children, child => {
+    return child.type && child.type.prototype === SidebarItem.prototype
+      ? child
+      : null;
+  }).filter(_ => !!_);
+  return (
+    <Menu
+      style={{ marginTop: "auto" }}
+      vertical
+      fitted="horizontally"
+      icon="labeled"
+    >
+      {children}
+    </Menu>
+  );
+};
+
+export const SidebarButton = ({ children, ...rest }) => <div>{children}</div>;
+
+export const SidebarContent = ({ children, ...rest }) => <div>{children}</div>;

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -1,6 +1,6 @@
-import React, { Component, Children } from "react";
+import React, { Children } from "react";
 import * as PropTypes from "prop-types";
-import { Segment, Menu } from "semantic-ui-react";
+import { Menu } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
 
 export const SidebarContainer = ({
@@ -13,7 +13,7 @@ export const SidebarContainer = ({
     style={{
       width: "86px",
       float: "left",
-      minHeight: fullscreenHeight ? "100vh" : "400px",
+      minHeight: fullscreenHeight ? "100vh" : "300px",
       maxHeight: fullscreenHeight ? "100vh" : "auto",
       display: "flex",
       flexDirection: "column",
@@ -25,41 +25,48 @@ export const SidebarContainer = ({
   </div>
 );
 
-const SidebarItem = ({ children, name, ...rest }, context) => {
-  const filteredSidebarButtonChildren = Children.map(children, child => {
-    // const a =
-    //   name === context.openDrawer
-    //     ? {
-    //         className:
-    //           typeof child.props.className === "function"
-    //             ? child.props.className(name)
-    //             : {}
-    //       }
-    //     : {};
-    // debugger;
-    return child.type && child.type.name === "SidebarButton"
+const filterChildrenByType = (children, type) => {
+  return Children.map(children, child => {
+    return child.type && child.type.name === type
       ? React.cloneElement(child)
       : null;
-  }).filter(_ => !!_);
-  const drawerContent = Children.map(children, child => {
-    return child.type && child.type.name === "SidebarContent" ? child : null;
-  }).filter(_ => !!_);
-  const fn = () => {
-    context.selectDrawer(name, drawerContent);
+  });
+};
+const SidebarItem = ({ children, name, ...rest }, context) => {
+  const filteredSidebarButtonChildren = filterChildrenByType(
+    children,
+    "SidebarButton"
+  );
+  const content = filterChildrenByType(children, "SidebarContent");
+  const updateDrawerSelection = () => {
+    context.selectDrawer({ name, content });
   };
-  if (
+
+  const defaultContentSelected =
     context.defaultOpenDrawer &&
     name === context.defaultOpenDrawer &&
-    !context.openDrawer
-  ) {
-    context.selectDrawer(name, drawerContent);
+    !context.openDrawer.content;
+
+  const openDrawerHasNoContent =
+    context.openDrawer &&
+    name === context.openDrawer.name &&
+    !context.openDrawer.content;
+
+  if (defaultContentSelected || openDrawerHasNoContent) {
+    updateDrawerSelection();
   }
 
-  return <Menu.Item onClick={fn}>{filteredSidebarButtonChildren}</Menu.Item>;
+  return (
+    <Menu.Item
+      onClick={!context.defaultOpenDrawer ? updateDrawerSelection : () => {}}
+    >
+      {filteredSidebarButtonChildren}
+    </Menu.Item>
+  );
 };
 
 SidebarItem.contextTypes = {
-  openDrawer: PropTypes.string,
+  openDrawer: PropTypes.object,
   selectDrawer: PropTypes.func,
   defaultOpenDrawer: PropTypes.string
 };
@@ -92,7 +99,7 @@ export const SidebarBottom = ({ children, ...rest }) => {
       fitted="horizontally"
       icon="labeled"
     >
-      {children}
+      {filteredChildren}
     </Menu>
   );
 };

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -47,15 +47,21 @@ const SidebarItem = ({ children, name, ...rest }, context) => {
   const fn = () => {
     context.selectDrawer(name, drawerContent);
   };
-  if (context.defaultOpenDrawer) {
-    fn();
+  if (
+    context.defaultOpenDrawer &&
+    name === context.defaultOpenDrawer &&
+    !context.openDrawer
+  ) {
+    context.selectDrawer(name, drawerContent);
   }
+
   return <Menu.Item onClick={fn}>{filteredSidebarButtonChildren}</Menu.Item>;
 };
 
 SidebarItem.contextTypes = {
   openDrawer: PropTypes.string,
-  selectDrawer: PropTypes.func
+  selectDrawer: PropTypes.func,
+  defaultOpenDrawer: PropTypes.string
 };
 
 export { SidebarItem };

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -3,7 +3,12 @@ import * as PropTypes from "prop-types";
 import { Segment, Menu } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
 
-export const SidebarContainer = ({ fullscreenHeight, children }) => (
+export const SidebarContainer = ({
+  fullscreenHeight,
+  children,
+  style,
+  ...rest
+}) => (
   <div
     style={{
       width: "86px",
@@ -11,8 +16,10 @@ export const SidebarContainer = ({ fullscreenHeight, children }) => (
       minHeight: fullscreenHeight ? "100vh" : "400px",
       maxHeight: fullscreenHeight ? "100vh" : "auto",
       display: "flex",
-      flexDirection: "column"
+      flexDirection: "column",
+      ...style
     }}
+    {...rest}
   >
     {children}
   </div>

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -25,26 +25,36 @@ export const SidebarContainer = ({
   </div>
 );
 
-const SidebarItem = ({ children, name }, context) => {
+const SidebarItem = ({ children, name, ...rest }, context) => {
   const filteredSidebarButtonChildren = Children.map(children, child => {
-    return child.type && child.type.name === "SidebarButton" ? child : null;
+    // const a =
+    //   name === context.openDrawer
+    //     ? {
+    //         className:
+    //           typeof child.props.className === "function"
+    //             ? child.props.className(name)
+    //             : {}
+    //       }
+    //     : {};
+    // debugger;
+    return child.type && child.type.name === "SidebarButton"
+      ? React.cloneElement(child)
+      : null;
   }).filter(_ => !!_);
   const drawerContent = Children.map(children, child => {
     return child.type && child.type.name === "SidebarContent" ? child : null;
   }).filter(_ => !!_);
-  return (
-    <Menu.Item
-      onClick={() => {
-        context.selectDrawer(name, drawerContent);
-      }}
-    >
-      {filteredSidebarButtonChildren}
-    </Menu.Item>
-  );
+  const fn = () => {
+    context.selectDrawer(name, drawerContent);
+  };
+  if (context.defaultOpenDrawer) {
+    fn();
+  }
+  return <Menu.Item onClick={fn}>{filteredSidebarButtonChildren}</Menu.Item>;
 };
 
 SidebarItem.contextTypes = {
-  selected: PropTypes.string,
+  openDrawer: PropTypes.string,
   selectDrawer: PropTypes.func
 };
 
@@ -83,4 +93,6 @@ export const SidebarBottom = ({ children, ...rest }) => {
 
 export const SidebarButton = ({ children, ...rest }) => <div>{children}</div>;
 
-export const SidebarContent = ({ children, ...rest }) => <div>{children}</div>;
+export const SidebarContent = ({ children, ...rest }, context) => (
+  <div {...rest}>{children}</div>
+);

--- a/src/components/Sidebar/SidebarComponents.js
+++ b/src/components/Sidebar/SidebarComponents.js
@@ -1,15 +1,6 @@
 import React, { Component, Children } from "react";
 import * as PropTypes from "prop-types";
-import {
-  Grid,
-  Sidebar as SemanticSidebar,
-  Segment,
-  Button,
-  Menu,
-  Image,
-  Icon,
-  Header
-} from "semantic-ui-react";
+import { Segment, Menu } from "semantic-ui-react";
 import "semantic-ui-css/semantic.min.css";
 
 export const SidebarContainer = ({ fullscreenHeight, children }) => (

--- a/src/components/Sidebar/SidebarComponents.jsx
+++ b/src/components/Sidebar/SidebarComponents.jsx
@@ -32,6 +32,7 @@ const filterChildrenByType = (children, type) => {
       : null;
   });
 };
+
 const SidebarItem = ({ children, name, ...rest }, context) => {
   const filteredSidebarButtonChildren = filterChildrenByType(
     children,
@@ -71,9 +72,7 @@ SidebarItem.contextTypes = {
   defaultOpenDrawer: PropTypes.string
 };
 
-export { SidebarItem };
-
-export const SidebarTop = ({ children, ...rest }) => {
+const SidebarTop = ({ children, ...rest }) => {
   const filteredChildren = Children.map(children, child => {
     return child.type && child.type.prototype === SidebarItem.prototype
       ? child
@@ -86,7 +85,7 @@ export const SidebarTop = ({ children, ...rest }) => {
   );
 };
 
-export const SidebarBottom = ({ children, ...rest }) => {
+const SidebarBottom = ({ children, ...rest }) => {
   const filteredChildren = Children.map(children, child => {
     return child.type && child.type.prototype === SidebarItem.prototype
       ? child
@@ -104,8 +103,16 @@ export const SidebarBottom = ({ children, ...rest }) => {
   );
 };
 
-export const SidebarButton = ({ children, ...rest }) => <div>{children}</div>;
+const SidebarButton = ({ children, ...rest }) => <div>{children}</div>;
 
-export const SidebarContent = ({ children, ...rest }, context) => (
+const SidebarContent = ({ children, ...rest }, context) => (
   <div {...rest}>{children}</div>
 );
+
+export {
+  SidebarItem,
+  SidebarButton,
+  SidebarContent,
+  SidebarTop,
+  SidebarBottom
+};

--- a/src/components/Sidebar/SidebarComponents.jsx
+++ b/src/components/Sidebar/SidebarComponents.jsx
@@ -73,24 +73,14 @@ SidebarItem.contextTypes = {
 };
 
 const SidebarTop = ({ children, ...rest }) => {
-  const filteredChildren = Children.map(children, child => {
-    return child.type && child.type.prototype === SidebarItem.prototype
-      ? child
-      : null;
-  }).filter(_ => !!_);
   return (
     <Menu vertical fitted="horizontally" icon="labeled" {...rest}>
-      {filteredChildren}
+      {filterChildrenByType(children, "SidebarItem")}
     </Menu>
   );
 };
 
 const SidebarBottom = ({ children, ...rest }) => {
-  const filteredChildren = Children.map(children, child => {
-    return child.type && child.type.prototype === SidebarItem.prototype
-      ? child
-      : null;
-  }).filter(_ => !!_);
   return (
     <Menu
       style={{ marginTop: "auto" }}
@@ -98,12 +88,14 @@ const SidebarBottom = ({ children, ...rest }) => {
       fitted="horizontally"
       icon="labeled"
     >
-      {filteredChildren}
+      {filterChildrenByType(children, "SidebarItem")}
     </Menu>
   );
 };
 
-const SidebarButton = ({ children, ...rest }) => <div>{children}</div>;
+const SidebarButton = ({ children, ...rest }) => (
+  <div {...rest}>{children}</div>
+);
 
 const SidebarContent = ({ children, ...rest }, context) => (
   <div {...rest}>{children}</div>

--- a/src/components/Sidebar/SidebarComponents.test.jsx
+++ b/src/components/Sidebar/SidebarComponents.test.jsx
@@ -1,0 +1,74 @@
+import React, { Component } from "react";
+import TestRenderer from "react-test-renderer";
+import {
+  SidebarItem,
+  SidebarButton,
+  SidebarContent,
+  SidebarTop,
+  SidebarBottom
+} from "./SidebarComponents";
+import { Sidebar } from "./Sidebar";
+
+const testText = "FooBar";
+const TestComponent = () => testText;
+
+describe("SidebarButton component", () => {
+  it("renders children", () => {
+    const anyTypeOfChild = <TestComponent />;
+    const out = TestRenderer.create(
+      <SidebarButton>{anyTypeOfChild}</SidebarButton>
+    ).root;
+    expect(out.findByType(TestComponent).hildren).toEqual([testText]);
+  });
+});
+
+describe("SidebarContent component", () => {
+  it("renders children", () => {
+    const anyTypeOfChild = <TestComponent />;
+    const out = TestRenderer.create(
+      <SidebarContent>{anyTypeOfChild}</SidebarContent>
+    ).root;
+    expect(out.findByType(TestComponent).children).toEqual([testText]);
+  });
+});
+
+describe("SidebarBottom component", () => {
+  it("only renders children of type SidebarItem", () => {
+    const out = TestRenderer.create(
+      <SidebarBottom>
+        <TestComponent />
+        <SidebarItem />
+      </SidebarBottom>
+    ).root;
+    expect(() => out.findByType(TestComponent)).toThrow();
+    expect(() => out.findByType(SidebarItem)).not.toThrow();
+  });
+});
+
+describe("SidebarTop component", () => {
+  it("only renders children of type SidebarItem", () => {
+    const out = TestRenderer.create(
+      <SidebarTop>
+        <TestComponent />
+        <SidebarItem />
+      </SidebarTop>
+    ).root;
+    expect(() => out.findByType(TestComponent)).toThrow();
+    expect(() => out.findByType(SidebarItem)).not.toThrow();
+  });
+});
+
+describe("SidebarItem component", () => {
+  it("only renders children of type SidebarButton", () => {
+    const out = TestRenderer.create(
+      <SidebarItem>
+        <TestComponent />
+        <SidebarButton>foo</SidebarButton>
+        <SidebarContent>bar</SidebarContent>
+      </SidebarItem>
+    ).root;
+    expect(() => out.findByType(TestComponent)).toThrow();
+    expect(() => out.findByType(SidebarButton)).not.toThrow();
+    expect(() => out.findByType(SidebarContent)).toThrow();
+  });
+});

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,0 +1,1 @@
+export { Sidebar } from "./Sidebar";

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -26,6 +26,10 @@ module.exports = {
           test: /\.css/,
           include: /node_modules/,
           loader: "style-loader!css-loader"
+        },
+        {
+          test: /\.(png|woff|woff2|eot|ttf|svg)$/,
+          loader: "url-loader"
         }
       ]
     }

--- a/test_package/preact/__snapshots__/preact.test.js.snap
+++ b/test_package/preact/__snapshots__/preact.test.js.snap
@@ -40,40 +40,23 @@ exports[`Render works 1`] = `<p>Hello</p>`;
 
 exports[`Sidebar works 1`] = `
 <div>
-  <div style="width: 86px; float: left; min-height: 400px; max-height: auto; display: flex; flex-direction: column;">
+  <div
+    style="min-height: 300px; max-height: auto;"
+    class="pushable"
+  >
     <div
-      fitted="horizontally"
-      class="ui vertical labeled icon menu"
+      style="width: auto;"
+      class="ui vertical ui push left visible sidebar menu"
     >
-      <a
-        title="Tick button"
-        data-test-id="drawerTick"
-        onClick={[Function anonymous]}
-        class="icon item"
-      >
-        <div>✔</div>
-      </a>
-    </div>
-    <div
-      style="margin-top: auto;"
-      fitted="horizontally"
-      class="ui vertical labeled icon menu"
-    >
-    </div>
-  </div>
-  <div>
-    <div
-      style="min-height: 400px; max-height: auto;"
-      class="pushable"
-    >
-      <div class="ui vertical ui push left thin visible sidebar menu">
-        <div class="pusher">
-          <div class="ui basic segment">
-            <span>Tick</span>
-          </div>
-        </div>
+      <div class="pusher">
+        <div class="ui basic segment"></div>
       </div>
     </div>
   </div>
+  <a
+    onClick={[Function anonymous]}
+    class="item"
+  >
+  </a>
 </div>
 `;

--- a/test_package/preact/__snapshots__/preact.test.js.snap
+++ b/test_package/preact/__snapshots__/preact.test.js.snap
@@ -37,3 +37,43 @@ exports[`GraphAppBase works 1`] = `
 `;
 
 exports[`Render works 1`] = `<p>Hello</p>`;
+
+exports[`Sidebar works 1`] = `
+<div>
+  <div style="width: 86px; float: left; min-height: 400px; max-height: auto; display: flex; flex-direction: column;">
+    <div
+      fitted="horizontally"
+      class="ui vertical labeled icon menu"
+    >
+      <a
+        title="Tick button"
+        data-test-id="drawerTick"
+        onClick={[Function anonymous]}
+        class="icon item"
+      >
+        <div>✔</div>
+      </a>
+    </div>
+    <div
+      style="margin-top: auto;"
+      fitted="horizontally"
+      class="ui vertical labeled icon menu"
+    >
+    </div>
+  </div>
+  <div>
+    <div
+      style="min-height: 400px; max-height: auto;"
+      class="pushable"
+    >
+      <div class="ui vertical ui push left thin visible sidebar menu">
+        <div class="pusher">
+          <div class="ui basic segment">
+            <span>Tick</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/test_package/preact/preact.test.js
+++ b/test_package/preact/preact.test.js
@@ -11,6 +11,7 @@ import { DesktopIntegration } from "../../dist/components/DesktopIntegration";
 import { DriverProvider } from "../../dist/components/DriverProvider";
 import { CypherEditor } from "../../dist/components/Editor";
 import { GraphAppBase } from "../../dist/components/GraphAppBase";
+import { Sidebar } from "../../dist/components/Sidebar";
 
 // Package exports lib/
 import { shallowEqual } from "../../dist/lib/utils";
@@ -75,6 +76,22 @@ test("GraphAppBase works", () => {
       integrationPoint={null}
       render={() => <p>Hello</p>}
       driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
+    />
+  );
+  expect(context.output()).toMatchSnapshot();
+});
+test("Sidebar works", () => {
+  const context = deep(
+    <Sidebar
+      openDrawer="Tick"
+      topNavItems={[
+        {
+          name: "Tick",
+          title: "Tick button",
+          icon: <div>{"\u2714"}</div>,
+          drawerContent: <span>Tick</span>
+        }
+      ]}
     />
   );
   expect(context.output()).toMatchSnapshot();

--- a/test_package/react/__snapshots__/package.test.js.snap
+++ b/test_package/react/__snapshots__/package.test.js.snap
@@ -276,69 +276,36 @@ exports[`Render works 1`] = `
 exports[`Sidebar works 1`] = `
 <div>
   <div
+    className="pushable"
     style={
       Object {
-        "display": "flex",
-        "flexDirection": "column",
-        "float": "left",
         "maxHeight": "auto",
-        "minHeight": "400px",
-        "width": "86px",
+        "minHeight": "300px",
       }
     }
   >
     <div
-      className="ui vertical labeled icon menu"
-      fitted="horizontally"
-    >
-      <a
-        className="icon item"
-        data-test-id="drawerTick"
-        onClick={[Function]}
-        title="Tick button"
-      >
-        <div>
-          ✔
-        </div>
-        
-      </a>
-    </div>
-    <div
-      className="ui vertical labeled icon menu"
-      fitted="horizontally"
+      className="ui vertical ui push left visible sidebar menu"
       style={
         Object {
-          "marginTop": "auto",
-        }
-      }
-    />
-  </div>
-  <div>
-    <div
-      className="pushable"
-      style={
-        Object {
-          "maxHeight": "auto",
-          "minHeight": "400px",
+          "width": "auto",
         }
       }
     >
       <div
-        className="ui vertical ui push left thin visible sidebar menu"
+        className="pusher"
       >
         <div
-          className="pusher"
-        >
-          <div
-            className="ui basic segment"
-          >
-            <span>
-              Tick
-            </span>
-          </div>
-        </div>
+          className="ui basic segment"
+        />
       </div>
     </div>
   </div>
+  <a
+    className="item"
+    onClick={[Function]}
+  >
+    
+  </a>
 </div>
 `;

--- a/test_package/react/__snapshots__/package.test.js.snap
+++ b/test_package/react/__snapshots__/package.test.js.snap
@@ -272,3 +272,73 @@ exports[`Render works 1`] = `
   Hello
 </p>
 `;
+
+exports[`Sidebar works 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "display": "flex",
+        "flexDirection": "column",
+        "float": "left",
+        "maxHeight": "auto",
+        "minHeight": "400px",
+        "width": "86px",
+      }
+    }
+  >
+    <div
+      className="ui vertical labeled icon menu"
+      fitted="horizontally"
+    >
+      <a
+        className="icon item"
+        data-test-id="drawerTick"
+        onClick={[Function]}
+        title="Tick button"
+      >
+        <div>
+          ✔
+        </div>
+        
+      </a>
+    </div>
+    <div
+      className="ui vertical labeled icon menu"
+      fitted="horizontally"
+      style={
+        Object {
+          "marginTop": "auto",
+        }
+      }
+    />
+  </div>
+  <div>
+    <div
+      className="pushable"
+      style={
+        Object {
+          "maxHeight": "auto",
+          "minHeight": "400px",
+        }
+      }
+    >
+      <div
+        className="ui vertical ui push left thin visible sidebar menu"
+      >
+        <div
+          className="pusher"
+        >
+          <div
+            className="ui basic segment"
+          >
+            <span>
+              Tick
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/test_package/react/package.test.js
+++ b/test_package/react/package.test.js
@@ -10,6 +10,7 @@ import { DesktopIntegration } from "../../dist/components/DesktopIntegration";
 import { DriverProvider } from "../../dist/components/DriverProvider";
 import { CypherEditor } from "../../dist/components/Editor";
 import { GraphAppBase } from "../../dist/components/GraphAppBase";
+import { Sidebar } from "../../dist/components/Sidebar";
 
 // Package exports lib/
 import { shallowEqual } from "../../dist/lib/utils";
@@ -75,6 +76,22 @@ test("GraphAppBase works", () => {
       integrationPoint={null}
       render={() => "Hello"}
       driverFactory={{ driver: () => resolvingDriver(0, "yes") }}
+    />
+  );
+  expect(out.toJSON()).toMatchSnapshot();
+});
+test("Sidebar works", () => {
+  const out = TestRenderer.create(
+    <Sidebar
+      openDrawer="Tick"
+      topNavItems={[
+        {
+          name: "Tick",
+          title: "Tick button",
+          icon: <div>{"\u2714"}</div>,
+          drawerContent: <span>Tick</span>
+        }
+      ]}
     />
   );
   expect(out.toJSON()).toMatchSnapshot();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,6 +3539,10 @@ har-validator@~5.0.3:
     ajv "^5.1.0"
     har-schema "^2.0.0"
 
+harmony-reflect@^1.4.6:
+  version "1.5.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/harmony-reflect/-/harmony-reflect-1.5.1.tgz#b54ca617b00cc8aef559bbb17b3d85431dc7e329"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -3772,6 +3776,12 @@ icss-utils@^2.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
   dependencies:
     postcss "^6.0.1"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
   version "1.1.8"


### PR DESCRIPTION
This introduces the `Sidebar` component to the graph app kit. The essence of the component comes from the look/feel of what the Neo4j Browser has as it's sidebar (a set of buttons aligned to the left hand side of the parent component that hide/shows 'drawers' on click). This implementation uses `semantic-ui` for it's foundations and can work in a controlled and uncontrolled way (see `yarn playground`).

There is also a set of smaller components (`SidebarItem`, `SidebarButton`, `SidebarContent`,  `SidebarTop` and ` SidebarBottom`) that are used to build the visual part of the Sidebar through the `render` prop.

Future enhancement: add `classNames` to the button component when the corresponding drawer is open. 