### PR TITLE
Correct cypher-editor import path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ import { Cypher } from "graph-app-kit/components/Cypher";
 import { DriverProvider } from "graph-app-kit/components/DriverProvider";
 import { Render } from "graph-app-kit/components/Render";
 import { Chart } from "graph-app-kit/components/Chart";
-import { CypherEditor } from "graph-app-kit/components/CypherEditor";
+import { CypherEditor } from "graph-app-kit/components/Editor";
 ```
 
 ## Component playground / library


### PR DESCRIPTION
Fixed error in cyper-editor import guide. Import path points to non-existing folder 'CypherEditor'. Changed to 'Editor'.