### PR TITLE
Correct imports in Editor/README.md

### DIFF
--- a/src/components/Editor/README.md
+++ b/src/components/Editor/README.md
@@ -8,6 +8,7 @@ Remember to include the required CSS somewhere in your app. Something like:
 ```javascript
 import "codemirror/lib/codemirror.css";
 import "codemirror/addon/lint/lint.css";
+import "codemirror/addon/hint/show-hint.css";
 import "cypher-codemirror/dist/cypher-codemirror-syntax.css";
 ```
 


### PR DESCRIPTION
Add required css import in Editor/README.md, because otherwise the content of the autocompletion box is misplaced.