### PR TITLE
Use url member in credentials from Desktop

### DIFF
--- a/src/components/GraphAppBase/helpers.js
+++ b/src/components/GraphAppBase/helpers.js
@@ -43,7 +43,7 @@ export const getActiveDatabaseCredentials = context => {
   const creds = integrationHelpers.getActiveCredentials("bolt", context);
   if (creds) {
     return {
-      host: `bolt://${creds.host}:${creds.port}`,
+      host: creds.url || `bolt://${creds.host}:${creds.port}`,
       encrypted: creds.tlsLevel === "REQUIRED",
       username: creds.username,
       password: creds.password


### PR DESCRIPTION
This means the protocol prefix is passed along from desktop - needed so that apps using these helpers will work with the `bolt+routing` protocol.